### PR TITLE
Add useful equates to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,3 +2,52 @@
 The directory holds example programs, written in assembly, that you can use on you Supercon.6 badge. These are intended to be more complex than the examples included in the guided tutorial, and should give you a better idea on how to utilize the more advanced capabilities of the badge hardware.
 
 We'd love to include example programs developed by the community, so if you've written an interesting piece of software for the badge, feel free to send a pull request.
+
+Here's a useful EQUates section to add to your assembly code to get nice symbolic names for special function registers:
+
+```
+; symbols for special registers
+Page        EQU 0xf0
+Clock       EQU 0xf1
+  F_250_kHz EQU 0
+  F_100_kHz EQU 1
+  F_30_kHz  EQU 2
+  F_10_kHz  EQU 3
+  F_3_kHz   EQU 4
+  F_1_kHz   EQU 5
+  F_500_Hz  EQU 6
+  F_200_Hz  EQU 7
+  F_100_Hz  EQU 8
+  F_50_Hz   EQU 9
+  F_20_Hz   EQU 10
+  F_10_Hz   EQU 11
+  F_5_Hz    EQU 12
+  F_2_Hz    EQU 13
+  F_1_Hz    EQU 14
+  F_1_2_Hz  EQU 15
+Sync        EQU 0xf2
+WrFlags     EQU 0xf3
+  LedsOff   EQU 3
+  MatrixOff EQU 2
+  InOutPos  EQU 1
+  RxTxPos   EQU 0
+RdFlags     EQU 0xf4
+  Vflag     EQU 1
+  UserSync  EQU 0       ; cleared after read
+SerCtl      EQU 0xf5
+  RxError   EQU 3       ; cleared after read
+SerLow      EQU 0xf6
+SerHigh     EQU 0xf7
+Received    EQU 0xf8
+AutoOff     EQU 0xf9
+OutB        EQU 0xfa
+InB         EQU 0xfb
+KeyStatus   EQU 0xfc
+  AltPress  EQU 3
+  AnyPress  EQU 2
+  LastPress EQU 1
+  JustPress EQU 0       ; cleared after read
+KeyReg      EQU 0xfd
+Dimmer      EQU 0xfe
+Random      EQU 0xff
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,20 @@ KeyStatus   EQU 0xfc
   LastPress EQU 1
   JustPress EQU 0       ; cleared after read
 KeyReg      EQU 0xfd
+  Btn_Mode  EQU 0
+  Btn_Opc_8 EQU 1
+  Btn_Opc_4 EQU 2
+  Btn_Opc_2 EQU 3
+  Btn_Opc_1 EQU 4
+  Btn_X_8   EQU 5
+  Btn_X_4   EQU 6
+  Btn_X_2   EQU 7
+  Btn_X_1   EQU 8
+  Btn_Y_8   EQU 9
+  Btn_Y_4   EQU 10
+  Btn_Y_2   EQU 11
+  Btn_Y_1   EQU 12
+  Btn_DtIn  EQU 13
 Dimmer      EQU 0xfe
-Random      EQU 0xff
+Random      EQU 0xff 
 ```


### PR DESCRIPTION
This adds the equates section I posted in Discord to the docs. Since the assembler doesn't handle includes, its best practice to put that in each assembler source file.