### PR TITLE
Add NIBBLE directive that works like BYTE

### DIFF
--- a/assembler/README.md
+++ b/assembler/README.md
@@ -110,6 +110,17 @@ In addition to the opcodes that directly translate to machine code, this assembl
   RET R0,0b0110
   RET R0,0b0001
   ```
+* #### NIBBLE
+
+  ```
+  NIBBLE 0b1100
+  NIBBLE 0b0001
+  ```
+  The NIBBLE pseudo-op is used to store an 4-bit value in a table. This is equivalent to writing RET R0, <number>, but looks better in a table as an analogue to the BYTE directive. Much like BYTE, you would retrieve these values by using the JSR register to jump into the table. The above example generates this code.
+  ```
+  RET R0,0b1100
+  RET R0,0b0001
+  ```
 
 * #### ASCII
   

--- a/assembler/assemble.py
+++ b/assembler/assemble.py
@@ -169,8 +169,8 @@ def parse_asm(lines_of_asm,hexfile_out=None):
             cm = None
 
             #Setup comment and source code display for non-special cases
-            #"BYTE" gets grouped in here to write these to just the first of the two generated lines
-            if tokens[0] not in Opcodes().pseudo_opcodes or (tokens[0] in (Opcodes().BYTE,Opcodes().GOTO,Opcodes().GOSUB) and i==0):
+            #"BYTE" and "NIBBLE" gets grouped in here to write these to just the first of the two generated lines
+            if tokens[0] not in Opcodes().pseudo_opcodes or (tokens[0] in (Opcodes().BYTE,Opcodes().NIBBLE,Opcodes().GOTO,Opcodes().GOSUB) and i==0):
                 if options.show_assembly_or_verbose():
                     cm = c.source
                 elif options.show_comments:
@@ -1010,6 +1010,11 @@ class Opcodes:
         #Split byte into low/high nibble and RET in that order
         return self.args_r0n([tokens[0],"R0",tokens[1]&0xF],self.RETR0N) + self.args_r0n([tokens[0],"R0",tokens[1]>>4],self.RETR0N)
 
+    def opcode_nibble(self, tokens):
+        arg_count_test(len(tokens),2)
+        validate_four_bit_int(tokens[1])
+        return self.args_r0n([tokens[0],"R0",tokens[1]&0xF],self.RETR0N)
+
     #Constants for opcode lookup
     EXTENDEDOP,ADDRXRY,ADCRXRY,SUBRXRY = 0b0000,0b0001,0b0010,0b0011
     SBBRXRY,ORRXRY,ANDRXRY,XORRXRY = 0b0100,0b0101,0b0110,0b0111
@@ -1026,6 +1031,7 @@ class Opcodes:
     ORG="ORG"
     ASCII="ASCII"
     BYTE="BYTE"
+    NIBBLE="NIBBLE"
     EQU="EQU"
 
     instructions = {
@@ -1055,8 +1061,9 @@ class Opcodes:
         ORG: opcode_org,
         ASCII: opcode_ascii,
         BYTE: opcode_byte,
+        NIBBLE: opcode_nibble,
         }
-    pseudo_opcodes = [GOTO, GOSUB, ORG, ASCII, BYTE]
+    pseudo_opcodes = [GOTO, GOSUB, ORG, ASCII, BYTE, NIBBLE]
     token_preceders = [instructions]+[EQU,"[",":",","]
     VALID_MESSAGE_CHARS = ' !"#$%&\'()*+,-./0123456789:<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
 


### PR DESCRIPTION
While this is already possible using RET R0, number, this provides some useful syntactic sugar when defining 4-bit value tables.