### PR TITLE
snake: Fix off-by-one bug in conditional jump.

### DIFF
--- a/examples/octav-snake/snake.asm
+++ b/examples/octav-snake/snake.asm
@@ -322,7 +322,8 @@ increment_score:
 	inc	r9
 	mov	r0,r9
 	mov	[score],r0
-	skip	nc,4
+	skip	c,1
+	jr	5
 ; Carry from the lowest nibble. Also increase difficulty.
 	inc	r8
 	mov	r0,r8
@@ -337,7 +338,7 @@ increment_score:
 	cp	r0,mid max_score
 	skip	z,1
 	ret	r0,1
-	; PLAYER WON! No empty squares left on the screen.
+; PLAYER WON! No empty squares left on the screen.
 	ret	r0,0
 
 ;; increase_difficulty()


### PR DESCRIPTION
This bug was introduced during some refactoring before checking in the code in this repo. It causes the snake to sometimes randomly veer left or right when eating food while going up or down.