### PR TITLE
feat(assembler): add RG register alias

### DIFF
--- a/assembler/assemble.py
+++ b/assembler/assemble.py
@@ -856,8 +856,11 @@ class Opcodes:
     def args_rgm(self, tokens,opcode):
         #BIT BSET BCLR BTG
         arg_count_test(len(tokens),3)
+        # handle R3 alias
+        if tokens[1] == "RS":
+            tokens[1] = "R3"
         if tokens[1] not in ["R0","R1","R2","R3"]:
-            raise ParserError("E::This opcode requires R0, R1, R2, or R3 as the first argument")
+            raise ParserError("E::This opcode requires R0, R1, R2, R3, or RS as the first argument")
         elif not is_int(tokens[2]) or not 0 <= tokens[2] < 4: 
             raise ParserError("E::This opcode requires a number [0..3] as the second argument")
         else:


### PR DESCRIPTION
The bit-twiddling opcodes have an interesting behavior where you can only specify registers R0-R3, but R3 is special and not really R3.

In the case of BIT, R3 is actually an alias for IN In the case of BSET/BCLR/BTG, R3 is actually for OUT

It is referred to as RS in the manual, I guess as a generic placeholder for IN/OUT.

Allow the assembler to recognize these aliases directly and convert to "R3", so that it's clearer what is meant