### PR TITLE
Emulator Behavior and Rendering fixes

### DIFF
--- a/emulator/bvm.py
+++ b/emulator/bvm.py
@@ -27,7 +27,7 @@ class BVM:
         self.window.title("BVM: 2022 Hackaday Supercon.6 Badge Virtual Machine")
         self.canvas = tk.Canvas(self.window, width=self.width, height=self.height, bd=0)
         bg = Image.open("gui_assets/badgeface.jpg")
-        bg.thumbnail((self.width, self.height), Image.ANTIALIAS)
+        bg.thumbnail((self.width, self.height), Image.LANCZOS)
         self.bgImage = ImageTk.PhotoImage(bg)
         self.canvas.create_image(0, 0, anchor=tk.NW, image=self.bgImage)
         self.canvas.pack()
@@ -161,9 +161,9 @@ class LED:
         else:
             self.px = 50/self.scale
         offImageObj = Image.open("gui_assets/leds/" + prefix + "off.jpg")
-        offImageObj.thumbnail((self.px, self.px), Image.ANTIALIAS)
+        offImageObj.thumbnail((self.px, self.px), Image.LANCZOS)
         onImageObj = Image.open("gui_assets/leds/" + prefix + "on.jpg")
-        onImageObj.thumbnail((self.px, self.px), Image.ANTIALIAS)
+        onImageObj.thumbnail((self.px, self.px), Image.LANCZOS)
         self.offImage = ImageTk.PhotoImage(offImageObj)
         self.onImage = ImageTk.PhotoImage(onImageObj)
         self.canvas = canvas

--- a/emulator/bvmCPU.py
+++ b/emulator/bvmCPU.py
@@ -315,8 +315,10 @@ class CPU:
         self.handleJumps(y)
         if self.ram[y] == 0:
             self.Z = 1
+            self.C = 1
         else:
             self.Z = 0
+            self.C = 0
 
 
     def DEC(self, args):
@@ -327,8 +329,11 @@ class CPU:
             self.Z = 1
         else:
             self.Z = 0
+        if self.ram[y] == 15:
+            self.C = 0
+        else:
+            self.C = 1
 
-    
 
     def DSZ(self, args):
         y = args['y']


### PR DESCRIPTION
This pull would correct 2 issues relating to the badge emulator.

1 - Pillow v10.0.0 deprecated the rendering [constant ANTIALIAS](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants)
2 - Emulator was not setting Carry / Zero flags correctly for INC and DEC instructions