### PR TITLE
Add user sync functionality

### DIFF
--- a/emulator/bvmCPU.py
+++ b/emulator/bvmCPU.py
@@ -281,6 +281,9 @@ class CPU:
             self.ram[args['nn']] = self.ram[0]
         elif args['mode'] ==  5: # R0,NN
             self.ram[0] = self.ram[args['nn']]
+            # UserSync; read clears bit 0
+            if self.ram[args['nn']] == 244:
+                self.cpu.ram[0xf4] &= 0b1110
         elif args['mode'] ==  6: # PC,NN
             # print(f"before mov PC, {hex(args['nn'])}" )
             self.ram[15] = (args['nn'] & 0xF0) >> 4


### PR DESCRIPTION
I (think I) implemented the Sync/UserSync functionality for the emulator. This is according to SFR_Rev4a.pdf page 12f.
My tests seem to show it working alright... clearly, it can't be relied upon as a hard timer, but for testing the functionality in general, it should be fine.

Since this is my first dabbling with something like an emulator for a 4-bit-cpu and my very first pull request ever, I'm very interested in everything I may have done wrongly or could have done better.

Also, thank you for this nice tool! The badge is a load of fun, and your emulator allowed for smooth progress when playing around with it, also it gave loads of insight in the inner workings where the manual wasn't quite enough to answer my questions.